### PR TITLE
Update Image Optimizer to v0.1.22

### DIFF
--- a/com.github.gijsgoudzwaard.image-optimizer.json
+++ b/com.github.gijsgoudzwaard.image-optimizer.json
@@ -53,8 +53,8 @@
         "config-opts": ["--buildtype=release"],
         "sources": [{
             "type": "archive",
-            "url": "https://github.com/GijsGoudzwaard/Image-Optimizer/archive/0.1.17.tar.gz",
-            "sha256": "41b7bbaa635fcee228a4fedd85c2a7a0095ca41fc9adcd80186bc3c3bf4de287"
+            "url": "https://github.com/GijsGoudzwaard/Image-Optimizer/archive/0.1.22.tar.gz",
+            "sha256": "1e41e81fba60b02995a8dbaf41a024ab12d639378a448271ea1831bc07cee732"
         },
         {
             "type": "patch",


### PR DESCRIPTION
Update Image Optimizer to v0.1.22. Fixes https://github.com/GijsGoudzwaard/Image-Optimizer/issues/65