### PR TITLE
Update platform and module versions, fix lint error

### DIFF
--- a/com.github.gijsgoudzwaard.image-optimizer.json
+++ b/com.github.gijsgoudzwaard.image-optimizer.json
@@ -1,10 +1,10 @@
 {
     "app-id": "com.github.gijsgoudzwaard.image-optimizer",
     "base": "io.elementary.BaseApp",
-    "base-version": "juno-22.08",
+    "base-version": "juno-23.08",
     "runtime": "org.freedesktop.Platform",
     "sdk": "org.freedesktop.Sdk",
-    "runtime-version": "22.08",
+    "runtime-version": "23.08",
     "command": "com.github.gijsgoudzwaard.image-optimizer",
     "finish-args": [
         /* X11 + XShm */

--- a/com.github.gijsgoudzwaard.image-optimizer.json
+++ b/com.github.gijsgoudzwaard.image-optimizer.json
@@ -15,27 +15,6 @@
     ],
     "modules": [
         {
-            "name": "graphviz",
-            "cleanup-platform": ["/include", "/bin", "/share/graphviz"],
-            "sources": [{
-                "type": "archive",
-                "url": "https://graphviz.gitlab.io/pub/graphviz/stable/SOURCES/graphviz.tar.gz",
-                "sha256": "ca5218fade0204d59947126c38439f432853543b0818d9d728c589dfe7f3a421"
-            }]
-        },
-        {
-            "name": "vala",
-            "cleanup-platform": ["*"],
-            "config-opts": [
-                "--enable-vapigen", "--enable-unversioned"
-            ],
-            "sources": [{
-                "type": "archive",
-                "url": "http://download.gnome.org/sources/vala/0.40/vala-0.40.25.tar.xz",
-                "sha256": "870fc7af58bbcfc82de6d11a96308a7bec6c180484ec431ce5bee68c2653b7df"
-            }]
-        },
-        {
             "name":"jpegoptim",
             "sources":[{
                 "type": "archive",

--- a/com.github.gijsgoudzwaard.image-optimizer.json
+++ b/com.github.gijsgoudzwaard.image-optimizer.json
@@ -41,8 +41,8 @@
         "config-opts": ["--buildtype=release"],
         "sources": [{
             "type": "archive",
-            "url": "https://github.com/GijsGoudzwaard/Image-Optimizer/archive/0.1.22.tar.gz",
-            "sha256": "1e41e81fba60b02995a8dbaf41a024ab12d639378a448271ea1831bc07cee732"
+            "url": "https://github.com/GijsGoudzwaard/Image-Optimizer/archive/refs/tags/0.1.25.tar.gz",
+            "sha256": "9f32da2d1c439e80f4f78b022d0043af0e24ed6f278955ed7ac09d5cc63d5d8e"
         },
         {
             "type": "patch",

--- a/com.github.gijsgoudzwaard.image-optimizer.json
+++ b/com.github.gijsgoudzwaard.image-optimizer.json
@@ -47,6 +47,10 @@
         {
             "type": "patch",
             "path": "elementary-theme.patch"  
-        }]
+        }],
+        "post-install": [
+            "mkdir -p /app/share/icons/hicolor/scalable/apps && mv /app/share/icons/hicolor/128x128@2/apps/${FLATPAK_ID}.svg /app/share/icons/hicolor/scalable/apps/${FLATPAK_ID}.svg",
+            "find /app/share/icons/hicolor -type f -not -path \"*scalable*\" -not -path \"*actions*\" -name \"*.svg\" -delete"
+        ]
     }]
 }

--- a/com.github.gijsgoudzwaard.image-optimizer.json
+++ b/com.github.gijsgoudzwaard.image-optimizer.json
@@ -18,8 +18,8 @@
             "name":"jpegoptim",
             "sources":[{
                 "type": "archive",
-                "url": "https://github.com/tjko/jpegoptim/archive/RELEASE.1.4.6.tar.gz",
-                "sha256": "c44dcfac0a113c3bec13d0fc60faf57a0f9a31f88473ccad33ecdf210b4c0c52"
+                "url": "https://github.com/tjko/jpegoptim/archive/v1.5.5.tar.gz",
+                "sha256": "90a309d1c092de358bb411d702281ac3039b489d03adb0bc3c4ef04cf0067d38"
             }]
         },
         {
@@ -31,8 +31,8 @@
             },
             "sources":[{
                 "type": "archive",
-                "url": "https://netcologne.dl.sourceforge.net/project/optipng/OptiPNG/optipng-0.7.7/optipng-0.7.7.tar.gz",
-                "sha256":"4f32f233cef870b3f95d3ad6428bfe4224ef34908f1b42b0badf858216654452"
+                "url": "https://netcologne.dl.sourceforge.net/project/optipng/OptiPNG/optipng-0.7.8/optipng-0.7.8.tar.gz",
+                "sha256":"25a3bd68481f21502ccaa0f4c13f84dcf6b20338e4c4e8c51f2cefbd8513398c"
             }]
         },
         {


### PR DESCRIPTION
- Update io.elementary.BaseApp and org.freedesktop.Platform versions to 23.08
- Remove graphviz and vala from modules because they're in io.elementary.BaseApp
- Update jpegoptim to 1.5.5
- Update optipng to 0.7.8
- Update image-optimizer to 0.1.25
- Fix "non-png-icon-in-hicolor-size-folder" lint error