### PR TITLE
Bump runtime to circe-24.08

### DIFF
--- a/com.github.gijsgoudzwaard.image-optimizer.json
+++ b/com.github.gijsgoudzwaard.image-optimizer.json
@@ -1,10 +1,10 @@
 {
     "app-id": "com.github.gijsgoudzwaard.image-optimizer",
     "base": "io.elementary.BaseApp",
-    "base-version": "juno-23.08",
+    "base-version": "circe-24.08",
     "runtime": "org.freedesktop.Platform",
     "sdk": "org.freedesktop.Sdk",
-    "runtime-version": "23.08",
+    "runtime-version": "24.08",
     "command": "com.github.gijsgoudzwaard.image-optimizer",
     "finish-args": [
         /* X11 + XShm */

--- a/com.github.gijsgoudzwaard.image-optimizer.json
+++ b/com.github.gijsgoudzwaard.image-optimizer.json
@@ -2,9 +2,9 @@
     "app-id": "com.github.gijsgoudzwaard.image-optimizer",
     "base": "io.elementary.BaseApp",
     "base-version": "circe-24.08",
-    "runtime": "org.freedesktop.Platform",
-    "sdk": "org.freedesktop.Sdk",
-    "runtime-version": "24.08",
+    "runtime": "org.gnome.Platform",
+    "sdk": "org.gnome.Sdk",
+    "runtime-version": "48",
     "command": "com.github.gijsgoudzwaard.image-optimizer",
     "finish-args": [
         /* X11 + XShm */

--- a/com.github.gijsgoudzwaard.image-optimizer.json
+++ b/com.github.gijsgoudzwaard.image-optimizer.json
@@ -4,7 +4,7 @@
     "base-version": "circe-24.08",
     "runtime": "org.gnome.Platform",
     "sdk": "org.gnome.Sdk",
-    "runtime-version": "48",
+    "runtime-version": "49",
     "command": "com.github.gijsgoudzwaard.image-optimizer",
     "finish-args": [
         /* X11 + XShm */

--- a/com.github.gijsgoudzwaard.image-optimizer.json
+++ b/com.github.gijsgoudzwaard.image-optimizer.json
@@ -1,5 +1,5 @@
 {
-    "app-id": "com.github.gijsgoudzwaard.image-optimizer",
+    "id": "com.github.gijsgoudzwaard.image-optimizer",
     "base": "io.elementary.BaseApp",
     "base-version": "circe-24.08",
     "runtime": "org.gnome.Platform",

--- a/com.github.gijsgoudzwaard.image-optimizer.json
+++ b/com.github.gijsgoudzwaard.image-optimizer.json
@@ -8,7 +8,7 @@
     "command": "com.github.gijsgoudzwaard.image-optimizer",
     "finish-args": [
         /* X11 + XShm */
-        "--share=ipc", "--socket=x11",
+        "--share=ipc", "--socket=fallback-x11",
         /* Wayland */
         "--socket=wayland",
         "--filesystem=home"


### PR DESCRIPTION
## Changes Summary
- Bump io.elementary.BaseApp to circe-24.08
- Switch from the fd.o runtime to GNOME runtime to use valac by default
    - We seemed to use the valac from io.elementary.BaseApp previously because the fd.o runtime itself doesn't ship it
    - However, it's removed from BaseApp in the following commit in favor of the GNOME runtime: flathub/io.elementary.BaseApp@b02b913
    - So, use GNOME runtime instead of the fd.o runtime for valac
- Misc fixes
    - Fix 'Legacy windowing system' warning on Flathub
    - Replace deprecated app-id with id
