### PR TITLE
Update optipng to 7.9.1

### DIFF
--- a/com.github.gijsgoudzwaard.image-optimizer.json
+++ b/com.github.gijsgoudzwaard.image-optimizer.json
@@ -31,8 +31,9 @@
             },
             "sources":[{
                 "type": "archive",
-                "url": "https://netcologne.dl.sourceforge.net/project/optipng/OptiPNG/optipng-0.7.8/optipng-0.7.8.tar.gz",
-                "sha256":"25a3bd68481f21502ccaa0f4c13f84dcf6b20338e4c4e8c51f2cefbd8513398c"
+                "url": "https://sourceforge.net/projects/optipng/files/OptiPNG/optipng-7.9.1/optipng-7.9.1.tar.gz/download",
+                "sha256":"c2579be58c2c66dae9d63154edcb3d427fef64cb00ec0aff079c9d156ec46f29",
+                "dest-filename": "optipng.tar.gz"
             }]
         },
         {


### PR DESCRIPTION
This fixes latest master a27a9398ddd30c6fe9d8a946d2e8e35ab23ec352 is failing to build:

```
user@elementary:~/work/tmp/com.github.gijsgoudzwaard.image-optimizer (master =)$ flatpak-builder builddir com.github.gijsgoudzwaard.image-optimizer.json --force-clean --user --install --install-deps-from=flathub
Dependency Sdk: org.gnome.Sdk 49
Updating org.gnome.Sdk/aarch64/49

Nothing to do.
Dependency Runtime: org.gnome.Platform 49
Updating org.gnome.Platform/aarch64/49

Nothing to do.
Dependency Base: io.elementary.BaseApp circe-24.08
Updating io.elementary.BaseApp/aarch64/circe-24.08
Info: org.gnome.Platform is end-of-life, with reason: The GNOME 47 runtime is no longer supported as of October 15, 2025. Please ask your application developer to migrate to a supported platform.
Info: org.gnome.Platform.Locale is end-of-life, with reason: The GNOME 47 runtime is no longer supported as of October 15, 2025. Please ask your application developer to migrate to a supported platform.

Nothing to do.
Downloading sources
Downloading https://netcologne.dl.sourceforge.net/project/optipng/OptiPNG/optipng-0.7.8/optipng-0.7.8.tar.gz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0Failed to download sources: module optipng: Could not resolve host: netcologne.dl.sourceforge.net
[ble: exit 1]
user@elementary:~/work/tmp/com.github.gijsgoudzwaard.image-optimizer (master =)$
```
